### PR TITLE
update node-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "file-loader": "^0.8.5",
     "json5": "^0.4.0",
     "node-libs-browser": "^0.5.3",
-    "node-sass": "^3.4.2",
+    "node-sass": "^4.14.1",
     "normalize.css": "^3.0.3",
     "react-dom": "^0.14.3",
     "react-google-analytics": "^0.2.0",


### PR DESCRIPTION
This allows the site to be built using the current LTS release of node, as otherwise things would crash while attempting to build node-sass (as a binary was also not available for older versions).